### PR TITLE
feature: show warning pane with missing objects

### DIFF
--- a/components/lnodetype-sidebar.spec.ts
+++ b/components/lnodetype-sidebar.spec.ts
@@ -28,6 +28,29 @@ describe('LNodeTypeSidebar filtering', () => {
     expect(sidebar.filteredLNodeTypes.length).to.equal(nodes.length);
   });
 
+  it('returns all nodes sorted alphabetically by id', () => {
+    sidebar.filter = '';
+    const sortedIds = [
+      'alpha',
+      'bar',
+      'baz',
+      'beta',
+      'delta',
+      'epsilon',
+      'eta',
+      'foo',
+      'foobar',
+      'gamma',
+      'iota',
+      'kappa',
+      'qux',
+      'theta',
+      'zeta',
+    ];
+    const ids = sidebar.filteredLNodeTypes.map(n => n.getAttribute('id') || '');
+    expect(ids).to.deep.equal(sortedIds);
+  });
+
   it('filters with OR (space)', () => {
     sidebar.filter = 'foo bar';
     const ids = sidebar.filteredLNodeTypes.map(n => n.getAttribute('id'));
@@ -35,6 +58,13 @@ describe('LNodeTypeSidebar filtering', () => {
     expect(ids).to.include('bar');
     expect(ids).to.include('foobar');
     expect(ids).to.include('qux');
+  });
+
+  it('returns filtered results sorted alphabetically by id', () => {
+    sidebar.filter = 'foo bar';
+    const sortedIds = ['bar', 'foo', 'foobar', 'qux'];
+    const ids = sidebar.filteredLNodeTypes.map(n => n.getAttribute('id') || '');
+    expect(ids).to.deep.equal(sortedIds);
   });
 
   it('filters with OR (comma)', () => {

--- a/components/lnodetype-sidebar.ts
+++ b/components/lnodetype-sidebar.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ScopedElementsMixin } from '@open-wc/scoped-elements/lit-element.js';
 
@@ -25,7 +25,25 @@ export class LNodeTypeSidebar extends ScopedElementsMixin(LitElement) {
   @state()
   filter: string = '';
 
+  private sortedLNodeTypes: Element[] = [];
+
   private debounceTimer?: number;
+
+  private static sortLNodeTypes(nodes: Element[]): Element[] {
+    return [...nodes].sort((a, b) => {
+      const aId = a.getAttribute('id')?.toLowerCase() || '';
+      const bId = b.getAttribute('id')?.toLowerCase() || '';
+      return aId.localeCompare(bId);
+    });
+  }
+
+  protected willUpdate(changedProperties: PropertyValues<this>) {
+    super.willUpdate(changedProperties);
+
+    if (changedProperties.has('lNodeTypes')) {
+      this.sortedLNodeTypes = LNodeTypeSidebar.sortLNodeTypes(this.lNodeTypes);
+    }
+  }
 
   private handleInput(e: Event) {
     const { value } = e.target as HTMLInputElement;
@@ -50,7 +68,9 @@ export class LNodeTypeSidebar extends ScopedElementsMixin(LitElement) {
   }
 
   get filteredLNodeTypes(): Element[] {
-    if (!this.filter.trim()) return this.lNodeTypes;
+    const sortedLNTypes = this.sortedLNodeTypes;
+
+    if (!this.filter.trim()) return sortedLNTypes;
     // If the filter includes words separated by &, treat as a single AND group (e.g. 'a & b', 'a&b', 'a &b', 'a& b').
     // Otherwise, split on comma or space (unless adjacent to &), so 'a b' and 'a,b' are separate OR groups.
     let groups: string[][] = [];
@@ -74,9 +94,9 @@ export class LNodeTypeSidebar extends ScopedElementsMixin(LitElement) {
         .filter(group => group.length > 0);
     }
 
-    if (groups.length === 0) return this.lNodeTypes;
+    if (groups.length === 0) return sortedLNTypes;
 
-    return this.lNodeTypes.filter(ln => {
+    return sortedLNTypes.filter(ln => {
       const id = ln.getAttribute('id')?.toLowerCase() || '';
       const desc = ln.getAttribute('desc')?.toLowerCase() || '';
       return groups.some(group =>
@@ -123,15 +143,6 @@ export class LNodeTypeSidebar extends ScopedElementsMixin(LitElement) {
         })}
       </oscd-list>
     </div>`;
-  }
-
-  updated(changedProperties: Map<string, unknown>) {
-    super.updated?.(changedProperties);
-    // Scroll oscd-list to top when lNodeTypes changes
-    if (changedProperties.has('lNodeTypes')) {
-      const oscdList = this.renderRoot.querySelector('oscd-list');
-      if (oscdList) oscdList.scrollTop = 0;
-    }
   }
 
   static styles = css`

--- a/foundation/utils.spec.ts
+++ b/foundation/utils.spec.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from '@open-wc/testing';
-import { removeDOsNotInSelection, computeOrphanedRemoves } from './utils.js';
+import {
+  removeDOsNotInSelection,
+  computeOrphanedRemoves,
+  getMissingMandatoryFields,
+  getEmptyReferencedElements,
+} from './utils.js';
 import { nsdSpeced } from '../scl-template-update.testfiles.js';
 
 describe('foundation/utils', () => {
@@ -163,6 +168,251 @@ describe('foundation/utils', () => {
       expect((result[0] as any).node as Element).to.equal(
         dataTypeTemplates.querySelector(`LNodeType[id="${mmxuId}"]`)
       );
+    });
+  });
+
+  describe('getMissingMandatoryFields', () => {
+    const tree: any = {
+      ReqDO: {
+        presCond: 'M',
+        children: {
+          stVal: {
+            mandatory: true,
+            children: {
+              q: {
+                mandatory: true,
+              },
+            },
+          },
+          optionalField: {
+            mandatory: false,
+          },
+        },
+      },
+      OptDO: {
+        presCond: 'O',
+        children: {
+          requiredUnderOptionalDo: {
+            mandatory: true,
+          },
+        },
+      },
+    };
+
+    it('returns missing mandatory subfields for present DOs', () => {
+      const selection = {
+        ReqDO: {},
+      };
+
+      const missing = getMissingMandatoryFields(tree, selection);
+
+      expect(missing).to.deep.equal([
+        {
+          path: ['ReqDO', 'stVal'],
+          kind: 'subfield',
+        },
+      ]);
+    });
+
+    it('returns no missing mandatory subfields for optional DOs missing in file', () => {
+      const selection = {
+        ReqDO: {
+          stVal: {
+            q: {},
+          },
+        },
+      };
+
+      const missing = getMissingMandatoryFields(tree, selection);
+
+      expect(missing).to.deep.equal([]);
+    });
+
+    it('returns deeper missing mandatory subfields for present branches', () => {
+      const selection = {
+        ReqDO: {
+          stVal: {},
+        },
+      };
+
+      const missing = getMissingMandatoryFields(tree, selection);
+
+      expect(missing).to.deep.equal([
+        {
+          path: ['ReqDO', 'stVal', 'q'],
+          kind: 'subfield',
+        },
+      ]);
+    });
+
+    it('returns missing fields sorted alphabetically by path', () => {
+      const unorderedTree: any = {
+        ReqDO: {
+          children: {
+            zField: { mandatory: true },
+            aField: { mandatory: true },
+          },
+        },
+      };
+
+      const selection = {
+        ReqDO: {},
+      };
+
+      const missing = getMissingMandatoryFields(unorderedTree, selection);
+
+      expect(missing.map(field => field.path.join('/'))).to.deep.equal([
+        'ReqDO/aField',
+        'ReqDO/zField',
+      ]);
+    });
+  });
+
+  describe('getEmptyReferencedElements', () => {
+    it('returns empty referenced DAType elements', () => {
+      const doc = new DOMParser().parseFromString(
+        `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"><DataTypeTemplates>
+          <LNodeType id="RBRF1" lnClass="RBRF">
+            <DO name="DetValA" type="DetValAType" />
+          </LNodeType>
+          <DOType id="DetValAType" cdc="ASG">
+            <DA name="setMag" bType="Struct" fc="SE" type="setMagType" />
+          </DOType>
+          <DAType id="setMagType" />
+        </DataTypeTemplates></SCL>`,
+        'application/xml'
+      );
+
+      const lNodeType = doc.querySelector('LNodeType')!;
+
+      expect(getEmptyReferencedElements(lNodeType)).to.deep.equal([
+        {
+          tagName: 'DAType',
+          id: 'setMagType',
+          referencePath: 'DetValA.setMag',
+        },
+      ]);
+    });
+
+    it('does not return non-empty DAType elements', () => {
+      const doc = new DOMParser().parseFromString(
+        `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"><DataTypeTemplates>
+          <LNodeType id="RBRF1" lnClass="RBRF">
+            <DO name="DetValA" type="DetValAType" />
+          </LNodeType>
+          <DOType id="DetValAType" cdc="ASG">
+            <DA name="setMag" bType="Struct" fc="SE" type="setMagType" />
+          </DOType>
+          <DAType id="setMagType">
+            <BDA name="f" bType="FLOAT32" />
+          </DAType>
+        </DataTypeTemplates></SCL>`,
+        'application/xml'
+      );
+
+      const lNodeType = doc.querySelector('LNodeType')!;
+
+      expect(getEmptyReferencedElements(lNodeType)).to.deep.equal([]);
+    });
+
+    it('reports empty referenced DOType elements', () => {
+      const doc = new DOMParser().parseFromString(
+        `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"><DataTypeTemplates>
+          <LNodeType id="RBRF1" lnClass="RBRF">
+            <DO name="EmptyDo" type="EmptyDoType" />
+          </LNodeType>
+          <DOType id="EmptyDoType" cdc="ASG" />
+        </DataTypeTemplates></SCL>`,
+        'application/xml'
+      );
+
+      const lNodeType = doc.querySelector('LNodeType')!;
+
+      expect(getEmptyReferencedElements(lNodeType)).to.deep.equal([
+        {
+          tagName: 'DOType',
+          id: 'EmptyDoType',
+          referencePath: 'EmptyDo',
+        },
+      ]);
+    });
+
+    it('returns empty referenced EnumType elements', () => {
+      const doc = new DOMParser().parseFromString(
+        `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"><DataTypeTemplates>
+          <LNodeType id="RBRF1" lnClass="RBRF">
+            <DO name="Mod" type="ModType" />
+          </LNodeType>
+          <DOType id="ModType" cdc="ENS">
+            <DA name="stVal" bType="Enum" fc="ST" type="EmptyEnumType" />
+          </DOType>
+          <EnumType id="EmptyEnumType" />
+        </DataTypeTemplates></SCL>`,
+        'application/xml'
+      );
+
+      const lNodeType = doc.querySelector('LNodeType')!;
+
+      expect(getEmptyReferencedElements(lNodeType)).to.deep.equal([
+        {
+          tagName: 'EnumType',
+          id: 'EmptyEnumType',
+          referencePath: 'Mod.stVal',
+        },
+      ]);
+    });
+
+    it('returns one empty element warning per usage path', () => {
+      const doc = new DOMParser().parseFromString(
+        `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"><DataTypeTemplates>
+          <LNodeType id="YPTR1" lnClass="YPTR">
+            <DO name="HiVRtg" type="SharedDoType" />
+            <DO name="LoVRtg" type="SharedDoType" />
+          </LNodeType>
+          <DOType id="SharedDoType" cdc="ASG">
+            <DA name="setMag" bType="Struct" fc="SE" type="setMagType" />
+          </DOType>
+          <DAType id="setMagType" />
+        </DataTypeTemplates></SCL>`,
+        'application/xml'
+      );
+
+      const lNodeType = doc.querySelector('LNodeType')!;
+
+      expect(getEmptyReferencedElements(lNodeType)).to.deep.equal([
+        {
+          tagName: 'DAType',
+          id: 'setMagType',
+          referencePath: 'HiVRtg.setMag',
+        },
+        {
+          tagName: 'DAType',
+          id: 'setMagType',
+          referencePath: 'LoVRtg.setMag',
+        },
+      ]);
+    });
+
+    it('does not return empty warnings for paths already flagged as missing mandatory fields', () => {
+      const doc = new DOMParser().parseFromString(
+        `<SCL xmlns="http://www.iec.ch/61850/2003/SCL"><DataTypeTemplates>
+          <LNodeType id="RBRF1" lnClass="RBRF">
+            <DO name="Blk" type="BlkType" />
+          </LNodeType>
+          <DOType id="BlkType" cdc="SPS" />
+        </DataTypeTemplates></SCL>`,
+        'application/xml'
+      );
+
+      const lNodeType = doc.querySelector('LNodeType')!;
+      const missingMandatoryFields: Array<{
+        path: string[];
+        kind: 'subfield';
+      }> = [{ path: ['Blk', 'stVal'], kind: 'subfield' }];
+
+      expect(
+        getEmptyReferencedElements(lNodeType, missingMandatoryFields)
+      ).to.deep.equal([]);
     });
   });
 });

--- a/foundation/utils.ts
+++ b/foundation/utils.ts
@@ -1,6 +1,266 @@
 import { Tree, TreeSelection } from '@openenergytools/tree-grid';
 import { EditV2 } from '@openscd/oscd-api';
 
+export type MissingMandatoryField = {
+  path: string[];
+  kind: 'subfield';
+};
+
+export type EmptyReferencedElement = {
+  tagName: 'DOType' | 'DAType' | 'EnumType';
+  id: string;
+  referencePath: string;
+};
+
+type ReferencedType = {
+  typeId: string;
+  referencePath: string;
+};
+
+type EmptyReferenceAnalysis = {
+  emptyTagName?: EmptyReferencedElement['tagName'];
+  childReferences: ReferencedType[];
+};
+
+type TreeNodeWithMetadata = {
+  children?: Tree;
+  mandatory?: boolean;
+  presCond?: string;
+};
+
+function hasSelectionPath(selection: TreeSelection, path: string[]): boolean {
+  let current: TreeSelection | undefined = selection;
+  for (const segment of path) {
+    if (!current || !Object.prototype.hasOwnProperty.call(current, segment))
+      return false;
+    current = current[segment];
+  }
+  return true;
+}
+
+function collectMissingMandatorySubfields(
+  tree: Tree,
+  selection: TreeSelection,
+  parentPath: string[] = []
+): MissingMandatoryField[] {
+  const missing: MissingMandatoryField[] = [];
+
+  Object.entries(tree).forEach(([name, rawNode]) => {
+    const node = (rawNode ?? {}) as TreeNodeWithMetadata;
+    const path = [...parentPath, name];
+    const presentInSelection = hasSelectionPath(selection, path);
+
+    if (node.mandatory && !presentInSelection) {
+      missing.push({ path, kind: 'subfield' });
+      return;
+    }
+
+    if (presentInSelection && node.children) {
+      missing.push(
+        ...collectMissingMandatorySubfields(node.children, selection, path)
+      );
+    }
+  });
+
+  return missing;
+}
+
+/**
+ * Returns an array of the mandatory fields that are missing from the selection.
+ * @param tree The tree structure representing the data model
+ * @param selection The current selection in the tree
+ * @returns An array of MissingMandatoryField objects
+ */
+export function getMissingMandatoryFields(
+  tree: Tree,
+  selection: TreeSelection
+): MissingMandatoryField[] {
+  const missing: MissingMandatoryField[] = [];
+
+  Object.entries(tree).forEach(([doName, rawNode]) => {
+    const node = (rawNode ?? {}) as TreeNodeWithMetadata;
+    const doPath = [doName];
+    const doPresentInSelection = hasSelectionPath(selection, doPath);
+    if (doPresentInSelection && node.children) {
+      missing.push(
+        ...collectMissingMandatorySubfields(node.children, selection, doPath)
+      );
+    }
+  });
+
+  return missing.sort((a, b) =>
+    a.path.join('/').localeCompare(b.path.join('/'))
+  );
+}
+
+function findTypeElementById(
+  dataTypeTemplates: Element,
+  id: string
+): Element | undefined {
+  return Array.from(dataTypeTemplates.children).find(child => {
+    const isKnownTypeTag =
+      child.tagName === 'DOType' ||
+      child.tagName === 'DAType' ||
+      child.tagName === 'EnumType';
+
+    return isKnownTypeTag && child.getAttribute('id') === id;
+  });
+}
+
+function getInitialReferencedTypes(lNodeType: Element): ReferencedType[] {
+  return Array.from(lNodeType.querySelectorAll(':scope > DO'))
+    .map(doElement => {
+      const typeId = doElement.getAttribute('type');
+      if (!typeId) return undefined;
+
+      return {
+        typeId,
+        referencePath: doElement.getAttribute('name'),
+      };
+    })
+    .filter((entry): entry is ReferencedType => !!entry);
+}
+
+function toChildReference(
+  element: Element,
+  parentReferencePath: string
+): ReferencedType | undefined {
+  const typeId = element.getAttribute('type');
+  const name = element.getAttribute('name');
+  if (!typeId || !name) return undefined;
+
+  return {
+    typeId,
+    referencePath: `${parentReferencePath}.${name}`,
+  };
+}
+
+function getChildReferences(
+  children: Element[],
+  parentReferencePath: string
+): ReferencedType[] {
+  return children
+    .map(child => toChildReference(child, parentReferencePath))
+    .filter((entry): entry is ReferencedType => !!entry);
+}
+
+function analyseReferencedType(
+  typeElement: Element,
+  referencePath: string
+): EmptyReferenceAnalysis {
+  if (typeElement.tagName === 'DOType') {
+    const directChildren = Array.from(
+      typeElement.querySelectorAll(':scope > DA, :scope > SDO')
+    );
+
+    return {
+      emptyTagName: directChildren.length === 0 ? 'DOType' : undefined,
+      childReferences: getChildReferences(directChildren, referencePath),
+    };
+  }
+
+  if (typeElement.tagName === 'DAType') {
+    const directChildren = Array.from(
+      typeElement.querySelectorAll(':scope > BDA')
+    );
+
+    return {
+      emptyTagName: directChildren.length === 0 ? 'DAType' : undefined,
+      childReferences: getChildReferences(directChildren, referencePath),
+    };
+  }
+
+  if (typeElement.tagName === 'EnumType') {
+    const enumValues = Array.from(
+      typeElement.querySelectorAll(':scope > EnumVal')
+    );
+
+    return {
+      emptyTagName: enumValues.length === 0 ? 'EnumType' : undefined,
+      childReferences: [],
+    };
+  }
+
+  return { childReferences: [] };
+}
+
+function hasMandatoryOverlap(
+  referencePath: string,
+  missingMandatoryFields: MissingMandatoryField[]
+): boolean {
+  const referencePathParts = referencePath
+    .split('.')
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  return missingMandatoryFields.some(missing => {
+    if (missing.path.length < referencePathParts.length) return false;
+    return referencePathParts.every(
+      (segment, index) => segment === missing.path[index]
+    );
+  });
+}
+
+/**
+ * Finds all referenced elements of an LNodeType that are empty (i.e., have no children).
+ * @param lNodeType The LNodeType element to analyse
+ * @param missingMandatoryFields An optional array of MissingMandatoryField objects to filter out empty elements that are part of mandatory fields
+ * @returns An array of EmptyReferencedElement objects representing the empty referenced elements
+ */
+export function getEmptyReferencedElements(
+  lNodeType: Element,
+  missingMandatoryFields: MissingMandatoryField[] = []
+): EmptyReferencedElement[] {
+  const dataTypeTemplates = lNodeType.closest('DataTypeTemplates');
+  if (!dataTypeTemplates) return [];
+
+  const referenceQueue: ReferencedType[] = getInitialReferencedTypes(lNodeType);
+
+  const processedReferences = new Set<string>();
+  const emptyElements: EmptyReferencedElement[] = [];
+
+  while (referenceQueue.length > 0) {
+    const currentReference = referenceQueue.shift();
+    if (!currentReference) break;
+
+    const { typeId, referencePath } = currentReference;
+    const referenceKey = `${typeId}:${referencePath}`;
+
+    if (!processedReferences.has(referenceKey)) {
+      processedReferences.add(referenceKey);
+
+      const typeElement = findTypeElementById(dataTypeTemplates, typeId);
+      if (typeElement) {
+        const analysis = analyseReferencedType(typeElement, referencePath);
+        if (analysis.emptyTagName) {
+          emptyElements.push({
+            tagName: analysis.emptyTagName,
+            id: typeId,
+            referencePath: referencePath,
+          });
+        }
+
+        referenceQueue.push(...analysis.childReferences);
+      }
+    }
+  }
+
+  return emptyElements
+    .filter(
+      element =>
+        !hasMandatoryOverlap(element.referencePath, missingMandatoryFields)
+    )
+    .sort((a, b) => {
+      const tagOrder = a.tagName.localeCompare(b.tagName);
+      if (tagOrder !== 0) return tagOrder;
+
+      const idOrder = a.id.localeCompare(b.id);
+      if (idOrder !== 0) return idOrder;
+
+      return a.referencePath.localeCompare(b.referencePath);
+    });
+}
+
 export function getLNodeTypes(doc: XMLDocument | undefined): Element[] {
   return Array.from(
     doc?.querySelectorAll(':root > DataTypeTemplates > LNodeType') ?? []

--- a/scl-template-update.spec.ts
+++ b/scl-template-update.spec.ts
@@ -51,6 +51,59 @@ describe('NsdTemplateUpdater', () => {
     it('displays an action button', () =>
       expect(element.shadowRoot?.querySelector('oscd-fab')).to.exist);
 
+    it('renders mandatory missing field indicators', async () => {
+      (element as any).missingMandatoryFields = [
+        { path: ['ReqDO', 'stVal'], kind: 'subfield' },
+        { path: ['ReqDO', 'stVal', 'q'], kind: 'subfield' },
+      ];
+
+      await element.updateComplete;
+
+      const panel = element.shadowRoot?.querySelector(
+        '[data-testid="mandatory-fields"]'
+      );
+
+      expect(panel).to.exist;
+      const iconTexts = Array.from(panel!.querySelectorAll('oscd-icon')).map(
+        icon => icon.textContent?.trim()
+      );
+      expect(iconTexts).to.deep.equal(['expand_more', 'error', 'error']);
+
+      expect(panel?.textContent).to.include('ReqDO');
+      expect(panel?.textContent).to.include('ReqDO / stVal');
+    });
+
+    it('renders empty DAType warning entries', async () => {
+      (element as any).missingMandatoryFields = [];
+      (element as any).emptyReferencedElements = [
+        {
+          tagName: 'DAType',
+          id: 'setMag$oscd$_fa38fd5c52d1b4a0',
+          referencePath: 'HiVRtg.setMag',
+        },
+        {
+          tagName: 'DAType',
+          id: 'setMag$oscd$_fa38fd5c52d1b4a0',
+          referencePath: 'LoVRtg.setMag',
+        },
+      ];
+
+      await element.updateComplete;
+
+      const panel = element.shadowRoot?.querySelector(
+        '[data-testid="mandatory-fields"]'
+      );
+
+      expect(panel).to.exist;
+      const normalizedText = panel?.textContent?.replace(/\s+/g, ' ') ?? '';
+      expect(normalizedText).to.include(
+        'Empty DAType: setMag$oscd$_fa38fd5c52d1b4a0 used by HiVRtg.setMag'
+      );
+      expect(normalizedText).to.include(
+        'Empty DAType: setMag$oscd$_fa38fd5c52d1b4a0 used by LoVRtg.setMag'
+      );
+    });
+
     it('updates MMXU on action button click', async () => {
       // Test the default 'update' behavior
       localStorage.removeItem('template-update-setting');

--- a/scl-template-update.ts
+++ b/scl-template-update.ts
@@ -717,7 +717,7 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
         @click=${this.toggleMissingFieldsPanel}
         aria-expanded=${!this.missingFieldsCollapsed}
       >
-        <span>Missing mandatory or empty elements in file</span>
+        <span>Missing mandatory or empty elements in LNodeType</span>
         <oscd-icon
           class="chevron ${this.missingFieldsCollapsed ? 'collapsed' : ''}"
           >expand_more</oscd-icon

--- a/scl-template-update.ts
+++ b/scl-template-update.ts
@@ -25,6 +25,7 @@ import { OscdIcon } from '@omicronenergy/oscd-ui/icon/OscdIcon.js';
 import { OscdCircularProgress } from '@omicronenergy/oscd-ui/progress/OscdCircularProgress.js';
 import { OscdOutlinedTextField } from '@omicronenergy/oscd-ui/textfield/OscdOutlinedTextField.js';
 import { OscdIconButton } from '@omicronenergy/oscd-ui/iconbutton/OscdIconButton.js';
+import { OscdAssistChip } from '@omicronenergy/oscd-ui/chips/OscdAssistChip.js';
 import { CdcChildren } from '@openscd/scl-lib/dist/tDataTypeTemplates/nsdToJson.js';
 
 import { AddDataObjectDialog } from './components/add-data-object-dialog.js';
@@ -43,6 +44,10 @@ import {
   filterSelection,
   removeDOsNotInSelection,
   computeOrphanedRemoves,
+  getMissingMandatoryFields,
+  getEmptyReferencedElements,
+  EmptyReferencedElement,
+  type MissingMandatoryField,
 } from './foundation/utils.js';
 
 export default class NsdTemplateUpdated extends ScopedElementsMixin(
@@ -57,6 +62,7 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
     'oscd-circular-progress': OscdCircularProgress,
     'oscd-outlined-text-field': OscdOutlinedTextField,
     'oscd-icon-button': OscdIconButton,
+    'oscd-assist-chip': OscdAssistChip,
     'add-data-object-dialog': AddDataObjectDialog,
     'delete-dialog': DeleteDialog,
     'lnodetype-sidebar': LNodeTypeSidebar,
@@ -120,6 +126,19 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
   @state()
   lNodeTypeDescription = '';
 
+  @state()
+  missingMandatoryFields: MissingMandatoryField[] = [];
+
+  @state()
+  emptyReferencedElements: EmptyReferencedElement[] = [];
+
+  @state()
+  missingFieldsCollapsed = false;
+
+  private toggleMissingFieldsPanel(): void {
+    this.missingFieldsCollapsed = !this.missingFieldsCollapsed;
+  }
+
   updated(changedProperties: Map<string, unknown>) {
     super.updated?.(changedProperties);
     if (changedProperties.has('doc')) {
@@ -153,13 +172,27 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
         this.doc!
       );
       if (tree) {
-        this.lNodeTypeSelection = lNodeTypeToSelection(updatedLNodeType);
-        this.nsdSelection = this.lNodeTypeSelection;
+        const fileSelection = lNodeTypeToSelection(updatedLNodeType);
+        this.lNodeTypeSelection = this.cloneSelection(fileSelection);
+        this.nsdSelection = this.cloneSelection(fileSelection);
+        this.missingMandatoryFields = getMissingMandatoryFields(
+          tree,
+          this.lNodeTypeSelection
+        );
+        this.emptyReferencedElements = getEmptyReferencedElements(
+          updatedLNodeType,
+          this.missingMandatoryFields
+        );
         this.treeUI.tree = tree;
-        this.treeUI.selection = this.lNodeTypeSelection;
+        this.treeUI.selection = this.cloneSelection(fileSelection);
         this.treeUI.requestUpdate();
       }
     }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private cloneSelection(selection: TreeSelection): TreeSelection {
+    return JSON.parse(JSON.stringify(selection));
   }
 
   private resetUI(full: boolean = false): void {
@@ -169,6 +202,8 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
       this.nsdSelection = undefined;
       this.disableAddDataObjectButton = true;
       this.lNodeTypeDescription = '';
+      this.missingMandatoryFields = [];
+      this.emptyReferencedElements = [];
     }
     if (this.treeUI) {
       this.treeUI.tree = {};
@@ -184,6 +219,59 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
   private showWarning(msg: string): void {
     this.warningMsg = msg;
     this.warningDialog?.show();
+  }
+
+  private focusTreePath(path: string[]): void {
+    if (!this.treeUI || path.length === 0) return;
+
+    const findRow = (targetPath: string[]): HTMLElement | undefined => {
+      const rows = Array.from(
+        this.treeUI.shadowRoot?.querySelectorAll('md-list-item') ?? []
+      );
+
+      return rows.find(item => {
+        const value = item.getAttribute('value');
+        const parentPath = JSON.parse(item.getAttribute('data-path') ?? '[]');
+        const candidatePath = [...parentPath, value].filter(Boolean);
+        return (
+          candidatePath.length === targetPath.length &&
+          candidatePath.every((segment, index) => segment === targetPath[index])
+        );
+      }) as HTMLElement | undefined;
+    };
+
+    const possiblePaths = Array.from({ length: path.length }, (_, index) =>
+      path.slice(0, path.length - index)
+    );
+
+    const row = possiblePaths
+      .map(candidatePath => findRow(candidatePath))
+      .find(Boolean) as HTMLElement | undefined;
+
+    if (!row) return;
+
+    // Scroll the row into view with a margin to account for fixed header in CoMPAS
+    row.style.scrollMarginTop = `${this.getHeaderOffset()}px`;
+    row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  private getHeaderOffset(): number {
+    const value = getComputedStyle(this)
+      .getPropertyValue('--app-bar-height')
+      .trim();
+
+    return parseFloat(value) || 0;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private warningPathFromEntry(
+    entry: MissingMandatoryField | EmptyReferencedElement
+  ): string[] {
+    if ('path' in entry) return entry.path;
+    return entry.referencePath
+      .split('.')
+      .map(part => part.trim())
+      .filter(Boolean);
   }
 
   private closeWarningDialog(): void {
@@ -461,9 +549,18 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
     const selectedLNodeTypeID = this.selectedLNodeType.getAttribute('id');
     const isReferenced = isLNodeTypeReferenced(this.doc!, selectedLNodeTypeID);
 
-    this.lNodeTypeSelection = lNodeTypeToSelection(this.selectedLNodeType);
+    const fileSelection = lNodeTypeToSelection(this.selectedLNodeType);
+    this.lNodeTypeSelection = this.cloneSelection(fileSelection);
+    this.missingMandatoryFields = getMissingMandatoryFields(
+      tree,
+      this.lNodeTypeSelection
+    );
+    this.emptyReferencedElements = getEmptyReferencedElements(
+      this.selectedLNodeType,
+      this.missingMandatoryFields
+    );
     this.treeUI.tree = tree;
-    this.treeUI.selection = this.lNodeTypeSelection;
+    this.treeUI.selection = this.cloneSelection(fileSelection);
     this.requestUpdate();
     this.treeUI.requestUpdate();
     await this.updateComplete;
@@ -607,12 +704,72 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
     </div>`;
   }
 
+  renderMissingMandatoryFields(): TemplateResult {
+    const totalCount =
+      this.missingMandatoryFields.length + this.emptyReferencedElements.length;
+
+    if (totalCount === 0) return html``;
+
+    return html`<div class="mandatory-fields" data-testid="mandatory-fields">
+      <button
+        class="mandatory-fields-header"
+        type="button"
+        @click=${this.toggleMissingFieldsPanel}
+        aria-expanded=${!this.missingFieldsCollapsed}
+      >
+        <span>Missing mandatory or empty elements in file</span>
+        <oscd-icon
+          class="chevron ${this.missingFieldsCollapsed ? 'collapsed' : ''}"
+          >expand_more</oscd-icon
+        >
+      </button>
+      ${this.missingFieldsCollapsed
+        ? ''
+        : html`<div class="mandatory-fields-list">
+            ${this.missingMandatoryFields.map(
+              field => html`<div class="warning-row">
+                <button
+                  class="warning-row-main"
+                  type="button"
+                  @click=${() => this.focusTreePath(field.path)}
+                >
+                  <oscd-icon>error</oscd-icon>
+                  <span class="warning-label">${field.path.join(' / ')}</span>
+                </button>
+                <span class="pill pill-success"
+                  >Auto-fixed on LNodeType update</span
+                >
+              </div>`
+            )}
+            ${this.emptyReferencedElements.map(
+              element => html`<div class="warning-row">
+                <button
+                  class="warning-row-main"
+                  type="button"
+                  title="Empty ${element.tagName}: ${element.id} used by ${element.referencePath}"
+                  @click=${() =>
+                    this.focusTreePath(this.warningPathFromEntry(element))}
+                >
+                  <oscd-icon>warning</oscd-icon>
+                  <span class="warning-label"
+                    >Empty ${element.tagName}: ${element.id} used by
+                    ${element.referencePath}</span
+                  >
+                </button>
+                <span class="pill pill-danger">Select a child element</span>
+              </div>`
+            )}
+          </div> `}
+    </div>`;
+  }
+
   render() {
     if (!this.doc) return html`<h1>Load SCL document first!</h1>`;
 
     return html`<div class="container">
         <div class="main-content">
           ${this.renderLNodeTypeControls()}
+          ${this.renderMissingMandatoryFields()}
           <tree-grid></tree-grid>
         </div>
         <lnodetype-sidebar
@@ -664,6 +821,8 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
       --md-list-container-color: var(--oscd-base2);
       --md-fab-container-color: var(--oscd-secondary);
       --md-dialog-container-color: var(--oscd-base3);
+      --md-fab-label-text-color: var(--oscd-base2);
+      --md-fab-icon-color: var(--oscd-base2);
       font-family: var(--oscd-theme-text-font, 'Roboto');
     }
 
@@ -741,6 +900,107 @@ export default class NsdTemplateUpdated extends ScopedElementsMixin(
       display: flex;
       gap: 16px;
       width: max-content;
+    }
+
+    .mandatory-fields {
+      border: 1px solid rgba(0, 0, 0, 0.12);
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 12px;
+      background: var(--oscd-base2);
+      color: var(--oscd-base00);
+    }
+
+    .mandatory-fields-title {
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+
+    .mandatory-fields-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      background: transparent;
+      border: none;
+      padding: 0;
+      margin-bottom: 8px;
+      cursor: pointer;
+      font: inherit;
+      font-weight: 600;
+      color: var(--oscd-base00);
+      text-align: left;
+    }
+
+    .mandatory-fields-header .chevron {
+      transition: transform 0.15s ease;
+    }
+
+    .mandatory-fields-header .chevron.collapsed {
+      transform: rotate(-90deg);
+    }
+
+    .mandatory-fields-list {
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      border-top: 1px solid rgba(0, 0, 0, 0.12);
+      padding-top: 4px;
+    }
+
+    .warning-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 6px 4px;
+    }
+
+    .warning-row-main {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      appearance: none;
+      border: none;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      text-align: left;
+      padding: 0;
+      cursor: pointer;
+    }
+
+    .warning-row-main:hover .warning-label,
+    .warning-row-main:focus-visible .warning-label {
+      color: var(--oscd-primary);
+    }
+
+    .warning-label {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .pill {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 20px;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .pill-success {
+      background: rgba(42, 161, 152, 0.15);
+      color: var(--oscd-accent-green, #2aa198);
+    }
+
+    .pill-danger {
+      background: rgba(220, 50, 47, 0.15);
+      color: var(--oscd-accent-red, #711210);
     }
   `;
 }


### PR DESCRIPTION
This PR:
- Adds a warning pane that:
  * shows any missing mandatory objects that are referenced by the selected `LNodeType`,
  * shows any empty elements that are referenced by the selected `LNodeType`
  * all errors are clickable and scroll to the problem node
  * is collapsable
- Adds alphabetic sorting to the LNodeTypes displayed in the sidebar

Warning pane:
<img width="983" height="332" alt="Screenshot 2026-08-13 at 15 15 26" src="https://github.com/user-attachments/assets/8545cdb4-25e8-416b-a6ac-21cfa1118f23" />

